### PR TITLE
fix commenting out a character for a scene

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -92,7 +92,7 @@
             actor: pair.actor,
             character: data[j][i],
             active:
-              data[j][i].trim() !== "" && data[j][i].trim().slice(2) !== "//",
+              data[j][i].trim() !== "" && data[j][i].trim().slice(0, 2) !== "//",
           };
         });
         newScenes.push({


### PR DESCRIPTION
`slice(2)` returns everything except the first 2 characters, `slice(0, 2)` returns the first 2 which is what is needed to compare