### PR TITLE
more usable autoreconnect ux & sanitize names for mixing station

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -374,14 +374,20 @@
 				{/if}
 			</button>
 			<button
-				on:click={$currentConnectionStatus.connected ? $currentConnection.close() : newConnection()}
+				on:click={$currentConnectionStatus.connected || $currentConnectionStatus.reconnecting
+					? $currentConnection.close()
+					: newConnection()}
 				class="connectionButton"
 				style="position: relative;"
 				style:display={rxActive ? "none" : null}
 			>
 				{$connectionMode === "osc" ? "x32-proxy" : $connectionMode === "ms" ? "Mixing Station" : ""}:
 				<br />
-				<span style:color={$currentConnectionStatus.connected ? "var(--green)" : "var(--red)"}>
+				<span
+					style:color={`var(--${
+						$currentConnectionStatus.connected ? "green" : $currentConnectionStatus.reconnecting ? "yellow" : "red"
+					})`}
+				>
 					<div class="iconlabel">
 						<box-icon name={$currentConnectionStatus.connected ? "wifi" : "wifi-off"} color="currentColor" size="1em" />
 						<strong>{$connectionAddress}</strong>
@@ -390,7 +396,13 @@
 						({$currentConnectionStatus.address})
 					{/if} -->
 				</span>
-				<span class="minilabel">tap to {$currentConnectionStatus.connected ? "disconnect" : "connect"}</span>
+				<span class="minilabel"
+					>tap to {$currentConnectionStatus.connected
+						? "disconnect"
+						: $currentConnectionStatus.reconnecting
+						? "stop reconnecting"
+						: "connect"}</span
+				>
 			</button>
 			{#if selectedConfig.sheetId && !selectedConfig.table && !rxActive}
 				<button
@@ -605,5 +617,6 @@
 		position: fixed;
 		top: 0;
 		left: 0;
+		z-index: 1000;
 	}
 </style>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -17,6 +17,7 @@
 		currentConnection,
 		currentConnectionStatus,
 		connectionMode,
+		ConnectionStatusEnum,
 	} from "./lib/stores";
 	import { newConnection, connectionAddress } from "./lib/connectionUtil";
 	import { configs, sheets, ddp, loadExternalConfig, updateSheet } from "./lib/db";
@@ -374,9 +375,7 @@
 				{/if}
 			</button>
 			<button
-				on:click={$currentConnectionStatus.connected || $currentConnectionStatus.reconnecting
-					? $currentConnection.close()
-					: newConnection()}
+				on:click={$currentConnectionStatus.status > 0 ? $currentConnection.close() : newConnection()}
 				class="connectionButton"
 				style="position: relative;"
 				style:display={rxActive ? "none" : null}
@@ -385,11 +384,23 @@
 				<br />
 				<span
 					style:color={`var(--${
-						$currentConnectionStatus.connected ? "green" : $currentConnectionStatus.reconnecting ? "yellow" : "red"
+						$currentConnectionStatus.status === ConnectionStatusEnum.CONNECTED
+							? "green"
+							: $currentConnectionStatus.status === ConnectionStatusEnum.CONNECTING
+							? "yellow"
+							: "red"
 					})`}
 				>
 					<div class="iconlabel">
-						<box-icon name={$currentConnectionStatus.connected ? "wifi" : "wifi-off"} color="currentColor" size="1em" />
+						<box-icon
+							name={$currentConnectionStatus.status === ConnectionStatusEnum.CONNECTED
+								? "wifi"
+								: $currentConnectionStatus.status === ConnectionStatusEnum.CONNECTING
+								? "hourglass"
+								: "wifi-off"}
+							color="currentColor"
+							size="1em"
+						/>
 						<strong>{$connectionAddress}</strong>
 					</div>
 					<!-- {#if $currentConnectionStatus.address}
@@ -397,10 +408,10 @@
 					{/if} -->
 				</span>
 				<span class="minilabel"
-					>tap to {$currentConnectionStatus.connected
+					>tap to {$currentConnectionStatus.status === ConnectionStatusEnum.CONNECTED
 						? "disconnect"
-						: $currentConnectionStatus.reconnecting
-						? "stop reconnecting"
+						: $currentConnectionStatus.status === ConnectionStatusEnum.CONNECTING
+						? "stop connecting"
 						: "connect"}</span
 				>
 			</button>

--- a/src/app.scss
+++ b/src/app.scss
@@ -15,6 +15,7 @@ body {
 	--accent-bright: rgb(65, 154, 255);
 	--accent-text: #fff;
 	--yellow: #fe0;
+	--yellow-text: #000;
 	--text: #fff;
 	--text-dimmed: #fff6;
 	// --modal-transition: 240ms cubic-bezier(0.38, 0, 0, 0.96);
@@ -58,6 +59,12 @@ body {
 .green {
 	background-color: var(--green);
 	color: var(--green-text);
+	border-color: transparent;
+}
+
+.yellow {
+	background-color: var(--yellow);
+	color: var(--yellow-text);
 	border-color: transparent;
 }
 

--- a/src/components/scene.svelte
+++ b/src/components/scene.svelte
@@ -1,7 +1,7 @@
 <script>
 	export let scene;
 	export let live = false;
-	import { connectionMode, currentConnectionStatus, oscConfig } from "../lib/stores";
+	import { connectionMode, currentConnectionStatus, ConnectionStatusEnum, oscConfig } from "../lib/stores";
 	import MeterCanvas from "./meterCanvas.svelte";
 </script>
 
@@ -20,7 +20,7 @@
 					class:accent={scene?.mics[i]?.active}
 					class:dne={!scene?.mics[i]}
 					class:meteringEnabled={$connectionMode === "osc" &&
-						$currentConnectionStatus.connected &&
+						$currentConnectionStatus.status === ConnectionStatusEnum.CONNECTED &&
 						$oscConfig.liveMetersEnabled}
 				>
 					<!-- <div class="channelMeter" style:height={`calc(100% * ${$channelMeters[i - 1]})`} /> -->

--- a/src/components/settings.svelte
+++ b/src/components/settings.svelte
@@ -69,6 +69,8 @@
 			<p>
 				{#if $currentConnectionStatus.connected}
 					<button class="green" on:click={$currentConnection.close()}>Connected (tap to disconnect)</button>
+				{:else if $currentConnectionStatus.reconnecting}
+					<button class="yellow" on:click={$currentConnection.close()}>Reconnecting (tap to stop)</button>
 				{:else}
 					<button class="red" on:click={newConnection}>Disconnected (tap to connect)</button>
 				{/if}

--- a/src/components/settings.svelte
+++ b/src/components/settings.svelte
@@ -5,7 +5,14 @@
 	import { connect, disconnect } from "../lib/mqtt";
 
 	import { newConnection } from "../lib/connectionUtil";
-	import { connectionMode, currentConnection, currentConnectionStatus, oscConfig, msConfig } from "../lib/stores";
+	import {
+		connectionMode,
+		currentConnection,
+		currentConnectionStatus,
+		ConnectionStatusEnum,
+		oscConfig,
+		msConfig,
+	} from "../lib/stores";
 </script>
 
 <Modal modalName="settings">
@@ -26,11 +33,11 @@
 			</ul>
 
 			<p>
-				Connection mode: <select disabled={$currentConnectionStatus.connected} bind:value={$connectionMode}>
+				Connection mode: <select disabled={$currentConnectionStatus.status > 0} bind:value={$connectionMode}>
 					<option value="osc">x32-proxy</option>
 					<option value="ms">Mixing Station</option>
 				</select>
-				{#if $currentConnectionStatus.connected}(disconnect to edit){/if}
+				{#if $currentConnectionStatus.status > 0}(disconnect to edit){/if}
 			</p>
 
 			{#if $connectionMode === "osc"}
@@ -40,7 +47,7 @@
 					<code>x32-proxy --ws --target your.mixer.ip.address</code> <br />
 					then, leaving the settings below blank, tap connect.
 				</p>
-				<div class="verti" disabled={$currentConnectionStatus.connected || null}>
+				<div class="verti" disabled={$currentConnectionStatus.status > 0 || null}>
 					<p>Host: <input type="text" bind:value={$oscConfig.host} /></p>
 					<p>Port: <input type="number" bind:value={$oscConfig.port} /></p>
 					<p>Secure: <input type="checkbox" bind:checked={$oscConfig.secure} /></p>
@@ -58,7 +65,7 @@
 					Once you have enabled the API, <strong>first</strong> connect to your mixer through Mixing Station.
 					<strong>Then,</strong> leaving the settings below blank, tap connect.
 				</p>
-				<div class="verti" disabled={$currentConnectionStatus.connected || null}>
+				<div class="verti" disabled={$currentConnectionStatus.status > 0 || null}>
 					<p>Host: <input type="text" bind:value={$msConfig.host} /></p>
 					<p>Port: <input type="number" bind:value={$msConfig.port} /></p>
 					<p>Secure: <input type="checkbox" bind:checked={$msConfig.secure} /></p>
@@ -67,10 +74,10 @@
 				</div>
 			{/if}
 			<p>
-				{#if $currentConnectionStatus.connected}
+				{#if $currentConnectionStatus.status === ConnectionStatusEnum.CONNECTED}
 					<button class="green" on:click={$currentConnection.close()}>Connected (tap to disconnect)</button>
-				{:else if $currentConnectionStatus.reconnecting}
-					<button class="yellow" on:click={$currentConnection.close()}>Reconnecting (tap to stop)</button>
+				{:else if $currentConnectionStatus.status === ConnectionStatusEnum.CONNECTING}
+					<button class="yellow" on:click={$currentConnection.close()}>Connecting (tap to stop)</button>
 				{:else}
 					<button class="red" on:click={newConnection}>Disconnected (tap to connect)</button>
 				{/if}

--- a/src/components/toast.svelte
+++ b/src/components/toast.svelte
@@ -57,7 +57,6 @@
 		border-radius: var(--rounding);
 		font-size: 0.7em;
 		max-width: 400px;
-		z-index: 1000;
 		box-shadow: 0 0 5px 0 var(--bg);
 	}
 </style>

--- a/src/lib/mixing-station.js
+++ b/src/lib/mixing-station.js
@@ -19,6 +19,7 @@ export class MixingStationConnection extends BaseConnection {
 			currentConnectionStatus.set({
 				connected: true,
 				address: new URL(this.client.url).host,
+				reconnecting: false,
 			});
 
 			const testKey = "ch.0.cfg.name";
@@ -69,9 +70,9 @@ export class MixingStationConnection extends BaseConnection {
 			if (this._pingInterval) this._pingInterval = clearInterval(this._pingInterval);
 			this._onSocketClose();
 		};
-		this.client.onerror = (error) => {
-			makeToast("Mixing Station WS Error", "", error);
-			currentConnectionStatus.set({ connected: false, address: null });
+		this.client.onerror = (event) => {
+			// let onclose handle close
+			if (event?.target?.readyState !== 3) makeToast("Mixing Station WS Error", "", "error");
 		};
 	}
 
@@ -90,7 +91,8 @@ export class MixingStationConnection extends BaseConnection {
 
 		this._sendMessage(channel, "mix.on", active);
 		if (this.nameCharacterLimit) name = name.substr(0, this.nameCharacterLimit);
-		this._sendMessage(channel, "cfg.name", name);
+		// mixing station won't accept forward slash or pipe even though sq does, so replace with something close enough
+		this._sendMessage(channel, "cfg.name", name.replace(/[\/\|]/g, "\\"));
 		// todo: different colors for different mixers? (not high priority)
 		this._sendMessage(channel, "cfg.color", active ? 4 : 1);
 	}

--- a/src/lib/osc.js
+++ b/src/lib/osc.js
@@ -1,6 +1,6 @@
 import osc from "osc-js";
 import { get, writable } from "svelte/store";
-import { makeToast, oscConfig, currentConnectionStatus } from "./stores";
+import { makeToast, oscConfig, currentConnectionStatus, ConnectionStatusEnum } from "./stores";
 import { BaseConnection } from "./baseConnection";
 
 export const channelMeters = writable([]);
@@ -37,9 +37,8 @@ export class OSCConnection extends BaseConnection {
 
 		this.client.on("open", () => {
 			currentConnectionStatus.set({
-				connected: true,
+				status: ConnectionStatusEnum.CONNECTED,
 				address: this.client.options.plugin.options.host,
-				reconnecting: false,
 			});
 			const liveRequestFunction = () => {
 				if (config.liveMetersEnabled) {
@@ -85,8 +84,8 @@ export class OSCConnection extends BaseConnection {
 		};
 	}
 
-	close() {
-		super.close();
+	close(ungraceful = false) {
+		super.close(ungraceful);
 		this.client.close();
 		clearInterval(this.liveRequestInterval);
 	}

--- a/src/lib/osc.js
+++ b/src/lib/osc.js
@@ -39,6 +39,7 @@ export class OSCConnection extends BaseConnection {
 			currentConnectionStatus.set({
 				connected: true,
 				address: this.client.options.plugin.options.host,
+				reconnecting: false,
 			});
 			const liveRequestFunction = () => {
 				if (config.liveMetersEnabled) {
@@ -52,11 +53,13 @@ export class OSCConnection extends BaseConnection {
 			this._onSocketClose();
 			clearInterval(this.liveRequestInterval);
 		});
-		this.client.on("error", (error) => {
+		this.client.on("error", (e) => {
 			console.error("OSC Error", error);
-			makeToast("OSC Error", "", "error");
-			currentConnectionStatus.set({ connected: false, address: null });
-			clearInterval(this.liveRequestInterval);
+			// let onclose handle close
+			if (e?.target?.readyState !== 3) {
+				makeToast("OSC Error", "", "error");
+				clearInterval(this.liveRequestInterval);
+			}
 		});
 		this.client.open();
 		// try {

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -29,7 +29,7 @@ export const msConfig = localStorageWritable("msConfig", {});
 
 /** @type {import("svelte/store").Writable<import("./connection").BaseConnection>} */
 export const currentConnection = writable(null);
-export const currentConnectionStatus = writable({ connected: false, address: null });
+export const currentConnectionStatus = writable({ connected: false, address: null, reconnecting: false });
 
 // disconnect when switching modes
 let lastConnectionMode = null;

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -29,7 +29,16 @@ export const msConfig = localStorageWritable("msConfig", {});
 
 /** @type {import("svelte/store").Writable<import("./connection").BaseConnection>} */
 export const currentConnection = writable(null);
-export const currentConnectionStatus = writable({ connected: false, address: null, reconnecting: false });
+
+/** @enum {number} */
+export const ConnectionStatusEnum = /** @type {const} */ ({
+	DISCONNECTED: 0,
+	// truthy values are not disconnected
+	CONNECTED: 1,
+	CONNECTING: 2,
+});
+/** @type {import("svelte/store").Writable<{status: typeof ConnectionStatusEnum[keyof typeof ConnectionStatusEnum]}>} */
+export const currentConnectionStatus = writable({ status: ConnectionStatusEnum.DISCONNECTED, address: null });
 
 // disconnect when switching modes
 let lastConnectionMode = null;


### PR DESCRIPTION
only 1 notification shown on connection failure: red error for no autoreconnect, yellow warning for trying

connection status light turns yellow while trying to autoreconnect (will go back to green on connection), clicking will stop trying to reconnect (back to initial state)